### PR TITLE
Added function dump(fstream*); added memset in reallocate();

### DIFF
--- a/compactstorage.cpp
+++ b/compactstorage.cpp
@@ -24,6 +24,9 @@
 #include "compactstorage.h"
 
 #include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 using namespace std;
 
@@ -61,6 +64,8 @@ void CompactStorage::freeBytes()
 void CompactStorage::reallocateBytes(int numberOfBytes)
 {
 	char* temp = new char[numberOfBytes];
+  // was getting mistakes without this using writeBool because it would get memory garbage
+  	memset(temp, 0, numberOfBytes);
 	for (int i = 0; i < m_numBytes; i++) {
 		temp[i] = m_bytes[i];
 	}
@@ -136,6 +141,8 @@ void CompactStorage::writeInt(int value, int bits)
 
 void CompactStorage::writeBool(bool value)
 {
+	// let's make sure we have space
+  	ensureRoomFor(1);
 	char byte = m_bytes[curByte()];
 	byte |= (int) value << (7 - curBit());
 	m_bytes[curByte()] = byte;

--- a/compactstorage.cpp
+++ b/compactstorage.cpp
@@ -104,6 +104,15 @@ void CompactStorage::dump()
 	cout << "^" << endl;
 }
 
+// dump storage in a file
+void CompactStorage::dump(fstream* fd)
+{
+  for (int curByte = 0; curByte < m_numBytes; curByte++) {
+		char str = m_bytes[curByte];
+    fd->write(&str, 1);
+  }
+}
+
 void CompactStorage::writeInt(int value, int bits)
 {
 	ensureRoomFor(bits);

--- a/compactstorage.h
+++ b/compactstorage.h
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include <fstream>
 #ifndef _COMPACTSTORAGE_H
 #define _COMPACTSTORAGE_H
 
@@ -31,6 +32,7 @@ class CompactStorage
 		~CompactStorage();
 
 		void dump();
+		void dump(std::fstream* fd);
 
 		void writeInt(int value, int bits);
 		void writeBool(bool value);


### PR DESCRIPTION
### Highlights
- Found bug when adding new bools that required bigger size of container. Fixed.
- Added dump() function to dump on file.

### Full Story
I came across your library when implementing Huffman's algorithm of compression for University Project. Really came in handy to write bit by bit arrays using the writeBool() function. 

I came across a bug, it had to do with memory garbage going into storage container when size was reallocated to a bigger size, because it copied everything from inside the container, but new spaces were left untouched. Because I was using things one bit at a time and the writeBool() uses bitwise or it created some bugs. I simply added a memset() to make sure new bits were all zero.

I also needed to write those arrays to a new file (the compressed file), so I added a new instance of the dump() function to write storage to file using fstream*.

Thanks you very much for this library, it was a real life saver. Very easy to use too, neat code.

